### PR TITLE
add redirect to netlify for api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Authors > [Paige Gorry](https://github.com/paigeegorry) |
 
 ## #API_Documentation
 
+Explore our API here: [strangerthingsapi.netlify.app](https://strangerthingsapi.netlify.app/docs)
+
 ### Routes 
 **`GET /api/v1/characters`** - get all characters (default 20 per page)
 

--- a/server.js
+++ b/server.js
@@ -4,6 +4,10 @@ const app = require('./lib/app');
 
 const PORT = process.env.PORT || 8080;
 
+app.get('/', function(req, res){
+  res.redirect('https://strangerthingsapi.netlify.app/docs');
+});
+
 app.listen(PORT, () => {
   console.log(`listening at PORT ${PORT}`);
 });


### PR DESCRIPTION
Testing notes:
1. Run `npm start`
2. Go to localhost:8080/
3. Verify you are redirected to https://strangerthingsapi.netlify.app/docs